### PR TITLE
Uses Object.isExtensible() to identify if require is extensible

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,16 +2,19 @@ var mod = require('module');
 
 var __get__ = require("rewire/lib/__get__").toString();
 var __set__ = require("rewire/lib/__set__").toString();
+var __with__ = require("rewire/lib/__with__").toString();
 
 var exportGet = "Object.defineProperty(module.exports, '__get__', { value: " + __get__ + ", writable: true });\n";
 var exportSet = "Object.defineProperty(module.exports, '__set__', { value: " + __set__ + ", writable: true });\n";
+var exportWith = "Object.defineProperty(module.exports, '__with__', { value: " + __with__ + ", writable: true });\n";
 
 var initalEnd = mod.wrapper[1];
 
-var embed = "\nif (typeof(module.exports) === 'object' || typeof(module.exports) === 'function') {\n" +
+var embed = "\nif (Object.isExtensible(module.exports)) {\n" +
   exportGet +
   exportSet +
-'}';
+  exportWith +
+  '}';
 
 var GlobalRewire = {
   enable: function() {

--- a/test/tests/tests.js
+++ b/test/tests/tests.js
@@ -48,10 +48,11 @@ describe('global-rewire', function() {
     assert.isUndefined(bool.__set__);
   });
 
-  it('should not make __get__ and __set__ enumerable', function() {
+  it('should not make __get__ and __set__ and __with__ enumerable', function() {
     var keys = require('../fixtures/keys');
     assert.notInclude(Object.keys(keys), '__get__');
     assert.notInclude(Object.keys(keys), '__set__');
+    assert.notInclude(Object.keys(keys), '__with__');
   });
 
   it('should attach to files without semicolons', function() {


### PR DESCRIPTION
I stumbled upon an issue where dependant libraries wouldn't allow them to be rewired, I guess they exposed objects that had been freezed or similar. 

I switched to a Object.isExtensible() identification instead, which seemed to have resolved it. 

I also added the **with** functionality since we used that in our project. 
